### PR TITLE
Add dynamic other project pages

### DIFF
--- a/src/_data/other_projects.js
+++ b/src/_data/other_projects.js
@@ -1,0 +1,23 @@
+const loadGallery = require('./helpers/load-gallery');
+
+module.exports = async () => {
+  const folderToName = {
+    highland: 'Highland House',
+    magnolia: 'Magnolia House',
+    eastside_hotel: 'Eastside Hotel'
+  };
+
+  const folders = Object.keys(folderToName);
+
+  const gallery = await loadGallery('other', folders, {
+    thumbnailDir: 'other_index_pics'
+  });
+
+  return gallery.map(item => ({
+    name: folderToName[item.name] || item.name,
+    slug: item.name.replace(/_/g, '-'),
+    imageDir: item.imageDir,
+    thumbnail: item.thumbnail,
+    images: item.images
+  }));
+};

--- a/src/other-projects.njk
+++ b/src/other-projects.njk
@@ -7,33 +7,16 @@ title: Other Projects - Sylvia Bolton Design
 <link rel="stylesheet" href="/assets/css/index.css">
 {% endblock %}
 
-<div class="container">
-  <div class="columnsContainer">
-    <div class="leftColumn" style="border: none;">
-      <!-- Optional: add a description or text here -->
-    </div>
-    <div class="rightColumn">
-      <div class="yacht-gallery">
+<main class="main-content">
+  <div class="yacht-gallery">
+    {% for project in other_projects %}
+      {% if project.thumbnail %}
         <div class="yacht-item">
-          <a href="/other-projects/highland/">
-            <img src="/assets/img/other_index_pics/highland.jpg" srcset="/assets/img/other_index_pics/highland.jpg" alt="Highland Project" loading="lazy" />
+          <a href="/other-projects/{{ project.slug }}/">
+            <img src="{{ project.thumbnail }}" srcset="{{ project.thumbnail }}" alt="{{ project.name }} thumbnail" loading="lazy" />
           </a>
         </div>
-        <div class="yacht-item">
-          <a href="/other-projects/magnolia/">
-            <img src="/assets/img/other_index_pics/magnolia.jpg" srcset="/assets/img/other_index_pics/magnolia.jpg" alt="Magnolia Project" loading="lazy" />
-          </a>
-        </div>
-        <div class="yacht-item">
-          <a href="/other-projects/eastside_hotel/">
-            <img src="/assets/img/other_index_pics/eastside_hotel.jpg" srcset="/assets/img/other_index_pics/eastside_hotel.jpg" alt="Eastside Hotel Project" loading="lazy" />
-          </a>
-        </div>
-        <div class="yacht-item">
-          <!-- Optionally add a fourth project or leave blank for grid symmetry -->
-        </div>
-      </div>
-    </div>
+      {% endif %}
+    {% endfor %}
   </div>
-  <br>
-</div>
+</main>

--- a/src/other_projects/item-single.njk
+++ b/src/other_projects/item-single.njk
@@ -1,0 +1,30 @@
+---
+layout: base.njk
+pagination:
+  data: other_projects
+  size: 1
+  alias: project
+permalink: "/other-projects/{{ project.slug }}/index.html"
+eleventyComputed:
+  title: "{{ project.name }} - Other Projects - Sylvia Bolton Design"
+---
+
+{% block pagestyles %}
+<link rel="stylesheet" href="/assets/css/single-page.css">
+{% endblock %}
+
+<div class="container">
+  <div class="columnsContainer">
+    <DIV class="in_progress_left_column">
+      <h2 id="boat_name">{{ project.name }}</h2>
+    </DIV>
+    <div class="rightColumn">
+      {% for image_filename in project.images %}
+        <img id='single_item_main_image'
+             src='{{ project.imageDir }}{{ image_filename }}'
+             srcset='{{ project.imageDir }}{{ image_filename }}'
+             alt="{{ project.name }} image {{ loop.index }}" loading="lazy" /><BR>
+      {% endfor %}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- build other_projects data set using `loadGallery`
- generate other project pages via pagination
- list other project thumbnails dynamically on Other Projects page

## Testing
- `npx eleventy` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684bcc6d740c8325aa5b5c4a4eb16f3b